### PR TITLE
generate pdf

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -63,6 +63,5 @@
     "Pdf": {
       "template_folder": "_themes.pdf"
     }
-  },
-  "need_generate_pdf": false
+  }
 }


### PR DESCRIPTION
# Öffentliche Beiträge werden derzeit nicht angenommen

Dieses Repository wurde veröffentlicht, um das Herunterladen und die Nutzung der Inhalte zur Erstellung individueller Hilfelösungen zu vereinfachen.
Derzeit werden keine öffentlichen Beiträge zu diesem Repository oder diesen Inhalten angenommen.
Wenn Sie etwas zu den von Microsoft veröffentlichten Inhalten beitragen möchten, gehen Sie zum Repository der englischen Fassung. Dort werden öffentliche Beiträge verarbeitet.
